### PR TITLE
Enable GitHub releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,7 @@ jobs:
     # specify the environment variables used by the packager, matching the secrets from the project on GitHub
     env:
        CF_API_KEY: ${{ secrets.CF_API_KEY }}
+       GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}
 
     # "steps" holds a list of all the steps needed to package and release our AddOn
     steps:


### PR DESCRIPTION
If you merge this PR and add [a personal access token](https://github.com/settings/tokens) to the repo's secrets named `GITHUB_TOKEN`, releases will be published to GitHub as well, enabling users to install directly from GitHub with clients like [WowUp](https://github.com/WowUp/WowUp), which no longer support Curse because of their policies.